### PR TITLE
Secondary world

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 stecs-derive = { path = "derive" }
 thunderdome = "0.6.1"
 hashbrown = { version = "0.14.0", features = ["raw"] }
+downcast-rs = "1.2.0"
 
 [workspace]
 members = ["derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,10 @@ name = "stecs"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 stecs-derive = { path = "derive" }
-
 thunderdome = "0.6.1"
+hashbrown = { version = "0.14.0", features = ["raw"] }
 
 [workspace]
 members = ["derive"]

--- a/derive/src/entity.rs
+++ b/derive/src/entity.rs
@@ -421,6 +421,10 @@ fn derive_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream2> {
             ::std::marker::Copy,
             ::std::fmt::Debug,
             ::std::cmp::PartialEq,
+            ::std::cmp::Eq,
+            ::std::cmp::PartialOrd,
+            ::std::cmp::Ord,
+            ::std::hash::Hash,
         )]
         #vis enum #ident_id {
             #(

--- a/examples/game.rs
+++ b/examples/game.rs
@@ -163,7 +163,7 @@ fn update_bullets(world: &mut World) {
         // For performance reasons, this check would usually be done with
         // a spatial acceleration structure rather than an inner loop.
         for (id, pos, health) in nest {
-            if bullet.pos.0 == pos.0 {
+            if bullet.pos.0 == pos.0 && *bullet.owner != id {
                 println!("Bullet by {:?} hit {:?}", bullet.owner, id);
                 health.0 -= 1;
             }

--- a/examples/game.rs
+++ b/examples/game.rs
@@ -102,16 +102,12 @@ fn align_to_target(world: &mut World) {
         .query_mut::<(&Position, &mut Target)>()
         .nest_off_diagonal::<(EntityId<Player>, EntityRef<Player>)>()
     {
-        // We can use `nest` to perform nested queries. `nest` prevents aliasing
-        // by disallowing to query the current entity. (In this case, the two
-        // queries are non-overlapping anyway, so we could also use
-        // `World::queries()` to obtain multiple independent queries, but I
-        // haven't actually implemented that yet.)
-
         if target.0.is_some() {
             continue;
         }
 
+        // We can use `nest` to perform nested queries. `nest` prevents aliasing
+        // by disallowing to query the current entity.
         target.0 = nest
             .into_iter()
             .min_by_key(|(_, player)| player.pos.distance(pos))
@@ -134,7 +130,7 @@ fn align_to_target(world: &mut World) {
             target.0 = None;
         }
 
-        vel.0 = (pos.0 - target_pos.0).signum();
+        vel.0 = (target_pos.0 - pos.0).signum();
     }
 }
 
@@ -212,7 +208,7 @@ fn print_world(world: &World) {
             EntityRef::<Entity>::Enemy(entity) => {
                 println!("Evil Enemy: {:?} {:?}", entity.pos, entity.health)
             }
-            EntityRef::<Entity>::Bullet(entity) => println!("Meh Bullet: {:?}", entity.pos),
+            EntityRef::<Entity>::Bullet(_) => {}
         }
     }
 }
@@ -220,7 +216,7 @@ fn print_world(world: &World) {
 fn main() {
     let mut world = create_world();
 
-    for _ in 0..10 {
+    for _ in 0..5 {
         run_tick(&mut world);
     }
 

--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -52,7 +52,7 @@ impl<E> Eq for EntityKey<E> {}
 
 impl<E> PartialOrd for EntityKey<E> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 

--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -1,6 +1,7 @@
 use std::{
     any::{type_name, TypeId},
     fmt::{self, Debug},
+    hash::{Hash, Hasher},
     marker::PhantomData,
     mem::transmute_copy,
     option,
@@ -44,6 +45,26 @@ impl<E> Debug for EntityKey<E> {
 impl<E> PartialEq for EntityKey<E> {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
+    }
+}
+
+impl<E> Eq for EntityKey<E> {}
+
+impl<E> PartialOrd for EntityKey<E> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
+impl<E> Ord for EntityKey<E> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl<E> Hash for EntityKey<E> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
     }
 }
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -5,7 +5,8 @@ use std::{
 };
 
 use crate::{
-    archetype::EntityKey, column::Column, query::fetch::Fetch, Component, Query, WorldData,
+    archetype::EntityKey, column::Column, query::fetch::Fetch, Component, Query, QueryShared,
+    WorldData,
 };
 
 pub trait Columns: Default + 'static {
@@ -31,7 +32,7 @@ pub trait Columns: Default + 'static {
 pub trait Entity: Sized + 'static {
     type Id: Copy + Debug + Eq + Ord + Hash + 'static;
 
-    type Ref<'f>: Query;
+    type Ref<'f>: QueryShared;
     /*where
     for<'w> <Self::Ref<'w> as Query>::Fetch<'w>: Fetch<Item<'w> = Self::Ref<'w>>;*/
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1,6 +1,7 @@
 use std::{
     cell::RefCell,
     fmt::{self, Debug},
+    hash::{Hash, Hasher},
 };
 
 use crate::{
@@ -28,7 +29,7 @@ pub trait Columns: Default + 'static {
 }
 
 pub trait Entity: Sized + 'static {
-    type Id: Copy + Debug + PartialEq + 'static;
+    type Id: Copy + Debug + Eq + Ord + Hash + 'static;
 
     type Ref<'f>: Query;
     /*where
@@ -80,6 +81,26 @@ impl<E: Entity> Debug for EntityId<E> {
 impl<E: Entity> PartialEq for EntityId<E> {
     fn eq(&self, other: &Self) -> bool {
         self.0.eq(&other.0)
+    }
+}
+
+impl<E: Entity> Eq for EntityId<E> {}
+
+impl<E: Entity> PartialOrd for EntityId<E> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
+impl<E: Entity> Ord for EntityId<E> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl<E: Entity> Hash for EntityId<E> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
     }
 }
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -88,7 +88,7 @@ impl<E: Entity> Eq for EntityId<E> {}
 
 impl<E: Entity> PartialOrd for EntityId<E> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod archetype;
 pub mod column;
 pub mod entity;
 pub mod query;
+pub mod secondary;
 pub mod world;
 
 pub use thunderdome;
@@ -29,6 +30,7 @@ pub use stecs_derive::Entity;
 pub use self::{
     entity::{Entity, EntityId, EntityRef, EntityRefMut},
     query::{Query, QueryShared},
+    secondary::{query::SecondaryQuery, query::SecondaryQueryShared, world::SecondaryWorld},
     world::{World, WorldData},
 };
 pub trait Component: 'static {}

--- a/src/query.rs
+++ b/src/query.rs
@@ -10,7 +10,7 @@ use crate::{
     column::{ColumnRawParts, ColumnRawPartsMut},
     entity::EntityVariant,
     world::WorldFetch,
-    Component, Entity, EntityId, SecondaryQuery, SecondaryWorld, WorldData,
+    Component, Entity, EntityId, SecondaryQuery, SecondaryQueryShared, SecondaryWorld, WorldData,
 };
 
 use self::{
@@ -142,6 +142,20 @@ where
     }
 
     pub fn join<J>(
+        self,
+        secondary_world: &'w SecondaryWorld<D::Entity>,
+    ) -> JoinQueryBorrow<'w, Q, J, D>
+    where
+        J: SecondaryQueryShared<D::Entity>,
+    {
+        JoinQueryBorrow {
+            data: self.data,
+            secondary_world,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn join_mut<J>(
         self,
         secondary_world: &'w SecondaryWorld<D::Entity>,
     ) -> JoinQueryBorrow<'w, Q, J, D>

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,6 +1,7 @@
 pub mod borrow_checker;
 pub mod fetch;
 pub mod iter;
+pub mod join;
 pub mod nest;
 
 use std::{any::type_name, marker::PhantomData};
@@ -9,12 +10,13 @@ use crate::{
     column::{ColumnRawParts, ColumnRawPartsMut},
     entity::EntityVariant,
     world::WorldFetch,
-    Component, Entity, EntityId, WorldData,
+    Component, Entity, EntityId, SecondaryQuery, SecondaryWorld, WorldData,
 };
 
 use self::{
     borrow_checker::BorrowChecker,
     fetch::{Fetch, UnitFetch, WithFetch, WithoutFetch},
+    join::JoinQueryBorrow,
     nest::NestOffDiagonalQueryBorrow,
 };
 
@@ -135,6 +137,20 @@ where
     {
         NestOffDiagonalQueryBorrow {
             data: self.data,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn join<J>(
+        self,
+        secondary_world: &'w SecondaryWorld<D::Entity>,
+    ) -> JoinQueryBorrow<'w, Q, J, D>
+    where
+        J: SecondaryQuery<D::Entity>,
+    {
+        JoinQueryBorrow {
+            data: self.data,
+            secondary_world,
             _phantom: PhantomData,
         }
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,6 +1,7 @@
 pub mod borrow_checker;
 pub mod fetch;
 pub mod iter;
+pub mod nest;
 
 use std::{any::type_name, marker::PhantomData};
 
@@ -14,7 +15,7 @@ use crate::{
 use self::{
     borrow_checker::BorrowChecker,
     fetch::{Fetch, UnitFetch, WithFetch, WithoutFetch},
-    iter::{NestDataFetchIter, NestOffDiagonal, WorldFetchIter},
+    nest::NestOffDiagonalQueryBorrow,
 };
 
 pub trait Query {
@@ -102,29 +103,6 @@ pub struct QueryBorrow<'w, Q, D> {
     _phantom: PhantomData<Q>,
 }
 
-impl<'w, Q, D> IntoIterator for QueryBorrow<'w, Q, D>
-where
-    Q: Query,
-    D: WorldData,
-{
-    type Item = <Q::Fetch<'w> as Fetch>::Item<'w>;
-
-    type IntoIter = WorldFetchIter<'w, Q::Fetch<'w>, D>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        // Safety: Check that the query does not specify borrows that violate
-        // Rust's borrowing rules.
-        <Q::Fetch<'w> as Fetch>::check_borrows(&mut BorrowChecker::new(type_name::<Q>()));
-
-        // Safety: A `QueryResult` exclusively borrows the `data: &'w mut D`.
-        // Also, `into_iter` consumes the `QueryResult` while maintaining the
-        // lifetime `'w`. Thus, it is not possible to construct references to
-        // entities in `data` outside of the returned iterator, thereby
-        // satisfying the requirement of `FetchIter`.
-        unsafe { WorldFetchIter::new(self.data) }
-    }
-}
-
 impl<'w, Q, D> QueryBorrow<'w, Q, D>
 where
     Q: Query,
@@ -200,43 +178,5 @@ where
 
         // Safety: TODO
         unsafe { world_fetch.get(id.get()) }
-    }
-}
-
-pub struct NestOffDiagonalQueryBorrow<'w, Q, J, S> {
-    data: &'w S,
-    _phantom: PhantomData<(Q, J)>,
-}
-
-// TODO: Implement `get` for `NestOffDiagonaQueryResult`.
-
-impl<'w, Q, J, D> IntoIterator for NestOffDiagonalQueryBorrow<'w, Q, J, D>
-where
-    Q: Query,
-    J: Query,
-    D: WorldData,
-{
-    type Item = (
-        <Q::Fetch<'w> as Fetch>::Item<'w>,
-        NestOffDiagonal<'w, J::Fetch<'w>, D>,
-    );
-
-    type IntoIter = NestDataFetchIter<'w, Q::Fetch<'w>, J::Fetch<'w>, D>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        // Safety: Check that the query does not specify borrows that violate
-        // Rust's borrowing rules.
-        <Q::Fetch<'w> as Fetch>::check_borrows(&mut BorrowChecker::new(type_name::<Q>()));
-        <J::Fetch<'w> as Fetch>::check_borrows(&mut BorrowChecker::new(type_name::<J>()));
-
-        // Safety: TODO
-        let query_iter = unsafe { WorldFetchIter::new(self.data) };
-        let nest_fetch = self.data.fetch();
-
-        NestDataFetchIter {
-            data: self.data,
-            query_iter,
-            nest_fetch,
-        }
     }
 }

--- a/src/query/fetch.rs
+++ b/src/query/fetch.rs
@@ -165,8 +165,6 @@ macro_rules! tuple_impl {
 
             unsafe fn get<'f>(&self, index: usize) -> Self::Item<'f> {
                 assert!(index < self.len());
-
-                ()
             }
 
             fn check_borrows(_: &mut BorrowChecker) {}

--- a/src/query/iter.rs
+++ b/src/query/iter.rs
@@ -248,3 +248,5 @@ where
         }
     }
 }
+
+// TODO: Size hints for iterators

--- a/src/query/iter.rs
+++ b/src/query/iter.rs
@@ -1,8 +1,31 @@
-use std::marker::PhantomData;
+use std::{any::type_name, marker::PhantomData};
 
-use crate::{entity::EntityVariant, world::WorldFetch, Entity, EntityId, WorldData};
+use crate::{world::WorldFetch, WorldData};
 
-use super::fetch::Fetch;
+use super::{borrow_checker::BorrowChecker, fetch::Fetch, Query, QueryBorrow};
+
+impl<'w, Q, D> IntoIterator for QueryBorrow<'w, Q, D>
+where
+    Q: Query,
+    D: WorldData,
+{
+    type Item = <Q::Fetch<'w> as Fetch>::Item<'w>;
+
+    type IntoIter = WorldFetchIter<'w, Q::Fetch<'w>, D>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        // Safety: Check that the query does not specify borrows that violate
+        // Rust's borrowing rules.
+        <Q::Fetch<'w> as Fetch>::check_borrows(&mut BorrowChecker::new(type_name::<Q>()));
+
+        // Safety: A `QueryResult` exclusively borrows the `data: &'w mut D`.
+        // Also, `into_iter` consumes the `QueryResult` while maintaining the
+        // lifetime `'w`. Thus, it is not possible to construct references to
+        // entities in `data` outside of the returned iterator, thereby
+        // satisfying the requirement of `FetchIter`.
+        unsafe { WorldFetchIter::new(self.data) }
+    }
+}
 
 // Safety: Before constructing a `FetchIter`, use `BorrowChecker` to ensure that
 // the query does not specify borrows that violate Rust's borrowing rules. Also,
@@ -26,7 +49,7 @@ where
         }
     }
 
-    fn skip_one(&mut self) {
+    pub(crate) fn skip_one(&mut self) {
         if self.i < self.fetch.len() {
             self.i += 1;
         }
@@ -100,153 +123,9 @@ where
         }
     }
 
-    fn skip_one(&mut self) {
+    pub(crate) fn skip_one(&mut self) {
         if let Some(fetch_iter) = self.current_fetch_iter.as_mut() {
             fetch_iter.skip_one();
         }
     }
 }
-
-pub struct NestOffDiagonal<'w, J, D>
-where
-    J: Fetch + 'w,
-    D: WorldData + 'w,
-{
-    pub(crate) data: &'w D,
-    pub(crate) ignore_id: EntityId<D::Entity>,
-    pub(crate) fetch: D::Fetch<'w, J>,
-}
-
-pub struct NestDataFetchIter<'w, F, J, D>
-where
-    F: Fetch,
-    J: Fetch + 'w,
-    D: WorldData,
-{
-    pub(crate) data: &'w D,
-    pub(crate) query_iter: WorldFetchIter<'w, (<D::Entity as Entity>::FetchId<'w>, F), D>,
-    pub(crate) nest_fetch: D::Fetch<'w, J>,
-}
-
-impl<'w, F, J, D> Iterator for NestDataFetchIter<'w, F, J, D>
-where
-    F: Fetch + 'w,
-    J: Fetch + 'w,
-    D: WorldData,
-{
-    type Item = (<F as Fetch>::Item<'w>, NestOffDiagonal<'w, J, D>);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let (id, item) = self.query_iter.next()?;
-        let nest = NestOffDiagonal {
-            data: self.data,
-            ignore_id: id,
-            fetch: self.nest_fetch.clone(),
-        };
-
-        Some((item, nest))
-    }
-}
-
-impl<'w, J, D> NestOffDiagonal<'w, J, D>
-where
-    J: Fetch,
-    D: WorldData + 'w,
-{
-    // This has to take an exclusive `self` reference to prevent violating
-    // Rust's borrowing rules if `J` contains an exclusive borrow, since `get()`
-    // could be called multiple times with the same `id`.
-    pub fn get_mut<'f, E>(&'f mut self, id: EntityId<E>) -> Option<J::Item<'f>>
-    where
-        'w: 'f,
-        E: EntityVariant<D::Entity>,
-    {
-        let id = id.to_outer();
-
-        // Safety: Do not allow borrowing the entity that the iterator that
-        // produced `self` currently points to.
-        if id == self.ignore_id {
-            // TODO: Consider panicking. Design question.
-            return None;
-        }
-
-        // Safety: TODO
-        unsafe { self.fetch.get(id.get()) }
-    }
-}
-
-pub struct NestOffDiagonalIter<'w, J, D>
-where
-    J: Fetch + 'w,
-    D: WorldData + 'w,
-{
-    ignore_id: EntityId<D::Entity>,
-    id_iter: WorldFetchIter<'w, <D::Entity as Entity>::FetchId<'w>, D>,
-    data_iter: WorldFetchIter<'w, J, D>,
-}
-
-impl<'w, J, D> Iterator for NestOffDiagonalIter<'w, J, D>
-where
-    J: Fetch + 'w,
-    D: WorldData + 'w,
-{
-    type Item = J::Item<'w>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let Some(mut id) = self.id_iter.next() else {
-            self.data_iter.next();
-            return None;
-        };
-
-        // At this point, `id_iter` has been advanced one more time than
-        // `data_iter`.
-
-        while id == self.ignore_id {
-            // Safety: We are viewing the entity that is to be ignored, so we
-            // must *not* call `next()` instead of `skip_one()`, since that
-            // could create an aliasing reference. Instead, we just let the
-            // pointers skip over the current entity.
-            self.data_iter.skip_one();
-
-            let next_id = self.id_iter.next();
-
-            let Some(next_id) = next_id else {
-                self.data_iter.next();
-                return None;
-            };
-
-            id = next_id;
-        }
-
-        // Safety: Again, `id_iter` has been advanced one more time than
-        // `data_iter`, and now we now know that they do *not* point at the same
-        // entity, so it is safe to call `next()` on `data_iter`.
-        self.data_iter.next()
-    }
-}
-
-impl<'w, J, D> IntoIterator for NestOffDiagonal<'w, J, D>
-where
-    J: Fetch,
-    D: WorldData + 'w,
-{
-    type Item = J::Item<'w>;
-
-    type IntoIter = NestOffDiagonalIter<'w, J, D>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        // Safety: Ids cannot be mutably borrowed, so there is no invalid aliasing.
-        let id_iter = unsafe { WorldFetchIter::new(self.data) };
-
-        // Safety: TODO
-        let data_iter = unsafe { WorldFetchIter::new(self.data) };
-
-        NestOffDiagonalIter {
-            ignore_id: self.ignore_id,
-            id_iter,
-            data_iter,
-        }
-    }
-}
-
-// TODO: Size hints for iterators

--- a/src/query/join.rs
+++ b/src/query/join.rs
@@ -1,0 +1,77 @@
+use std::{any::type_name, marker::PhantomData};
+
+use crate::{
+    secondary::query::SecondaryFetch, Entity, Query, SecondaryQuery, SecondaryWorld, WorldData,
+};
+
+use super::{borrow_checker::BorrowChecker, fetch::Fetch, iter::WorldFetchIter};
+
+pub struct JoinQueryBorrow<'w, Q, J, D>
+where
+    D: WorldData,
+{
+    pub(crate) data: &'w D,
+    pub(crate) secondary_world: &'w SecondaryWorld<D::Entity>,
+    pub(crate) _phantom: PhantomData<(Q, J)>,
+}
+
+impl<'w, Q, J, D> IntoIterator for JoinQueryBorrow<'w, Q, J, D>
+where
+    Q: Query,
+    J: SecondaryQuery<D::Entity>,
+    D: WorldData,
+{
+    type Item = (
+        <Q::Fetch<'w> as Fetch>::Item<'w>,
+        <J::Fetch<'w> as SecondaryFetch<'w, D::Entity>>::Item<'w>,
+    );
+
+    type IntoIter = JoinQueryFetchIter<'w, Q::Fetch<'w>, J::Fetch<'w>, D>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        // Safety: Check that the query does not specify borrows that violate
+        // Rust's borrowing rules.
+        <Q::Fetch<'w> as Fetch>::check_borrows(&mut BorrowChecker::new(type_name::<Q>()));
+        <J::Fetch<'w> as SecondaryFetch<'w, D::Entity>>::check_borrows(&mut BorrowChecker::new(
+            type_name::<J>(),
+        ));
+
+        // Safety: TODO
+        let query_iter = unsafe { WorldFetchIter::new(self.data) };
+
+        let secondary_fetch =
+            <J::Fetch<'w> as SecondaryFetch<'w, D::Entity>>::new(self.secondary_world);
+
+        JoinQueryFetchIter {
+            query_iter,
+            secondary_fetch,
+        }
+    }
+}
+
+pub struct JoinQueryFetchIter<'w, F, J, D>
+where
+    F: Fetch + 'w,
+    J: SecondaryFetch<'w, D::Entity>,
+    D: WorldData,
+{
+    query_iter: WorldFetchIter<'w, (<D::Entity as Entity>::FetchId<'w>, F), D>,
+    secondary_fetch: Option<J>,
+}
+
+impl<'w, F, J, D> Iterator for JoinQueryFetchIter<'w, F, J, D>
+where
+    F: Fetch + 'w,
+    J: SecondaryFetch<'w, D::Entity>,
+    D: WorldData,
+{
+    type Item = (F::Item<'w>, J::Item<'w>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (id, item) = self.query_iter.next()?;
+        let secondary_fetch = self.secondary_fetch.as_ref()?;
+
+        // Safety: `FetchIter` does not generate duplicate IDs.
+        unsafe { secondary_fetch.get(id) }.map(|secondary_item| (item, secondary_item))
+    }
+}

--- a/src/query/nest.rs
+++ b/src/query/nest.rs
@@ -1,0 +1,187 @@
+use std::{any::type_name, marker::PhantomData};
+
+use crate::{entity::EntityVariant, world::WorldFetch, Entity, EntityId, Query, WorldData};
+
+use super::{borrow_checker::BorrowChecker, fetch::Fetch, iter::WorldFetchIter};
+
+pub struct NestOffDiagonalQueryBorrow<'w, Q, J, S> {
+    pub(crate) data: &'w S,
+    pub(crate) _phantom: PhantomData<(Q, J)>,
+}
+
+// TODO: Implement `get` for `NestOffDiagonaQueryResult`.
+
+impl<'w, Q, J, D> IntoIterator for NestOffDiagonalQueryBorrow<'w, Q, J, D>
+where
+    Q: Query,
+    J: Query,
+    D: WorldData,
+{
+    type Item = (
+        <Q::Fetch<'w> as Fetch>::Item<'w>,
+        NestOffDiagonal<'w, J::Fetch<'w>, D>,
+    );
+
+    type IntoIter = NestDataFetchIter<'w, Q::Fetch<'w>, J::Fetch<'w>, D>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        // Safety: Check that the query does not specify borrows that violate
+        // Rust's borrowing rules.
+        <Q::Fetch<'w> as Fetch>::check_borrows(&mut BorrowChecker::new(type_name::<Q>()));
+        <J::Fetch<'w> as Fetch>::check_borrows(&mut BorrowChecker::new(type_name::<J>()));
+
+        // Safety: TODO
+        let query_iter = unsafe { WorldFetchIter::new(self.data) };
+        let nest_fetch = self.data.fetch();
+
+        NestDataFetchIter {
+            data: self.data,
+            query_iter,
+            nest_fetch,
+        }
+    }
+}
+pub struct NestOffDiagonal<'w, J, D>
+where
+    J: Fetch + 'w,
+    D: WorldData + 'w,
+{
+    pub(crate) data: &'w D,
+    pub(crate) ignore_id: EntityId<D::Entity>,
+    pub(crate) fetch: D::Fetch<'w, J>,
+}
+
+pub struct NestDataFetchIter<'w, F, J, D>
+where
+    F: Fetch,
+    J: Fetch + 'w,
+    D: WorldData,
+{
+    pub(crate) data: &'w D,
+    pub(crate) query_iter: WorldFetchIter<'w, (<D::Entity as Entity>::FetchId<'w>, F), D>,
+    pub(crate) nest_fetch: D::Fetch<'w, J>,
+}
+
+impl<'w, F, J, D> Iterator for NestDataFetchIter<'w, F, J, D>
+where
+    F: Fetch + 'w,
+    J: Fetch + 'w,
+    D: WorldData,
+{
+    type Item = (<F as Fetch>::Item<'w>, NestOffDiagonal<'w, J, D>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (id, item) = self.query_iter.next()?;
+        let nest = NestOffDiagonal {
+            data: self.data,
+            ignore_id: id,
+            fetch: self.nest_fetch.clone(),
+        };
+
+        Some((item, nest))
+    }
+}
+
+impl<'w, J, D> NestOffDiagonal<'w, J, D>
+where
+    J: Fetch,
+    D: WorldData + 'w,
+{
+    // This has to take an exclusive `self` reference to prevent violating
+    // Rust's borrowing rules if `J` contains an exclusive borrow, since `get()`
+    // could be called multiple times with the same `id`.
+    pub fn get_mut<'f, E>(&'f mut self, id: EntityId<E>) -> Option<J::Item<'f>>
+    where
+        'w: 'f,
+        E: EntityVariant<D::Entity>,
+    {
+        let id = id.to_outer();
+
+        // Safety: Do not allow borrowing the entity that the iterator that
+        // produced `self` currently points to.
+        if id == self.ignore_id {
+            // TODO: Consider panicking. Design question.
+            return None;
+        }
+
+        // Safety: TODO
+        unsafe { self.fetch.get(id.get()) }
+    }
+}
+
+pub struct NestOffDiagonalIter<'w, J, D>
+where
+    J: Fetch + 'w,
+    D: WorldData + 'w,
+{
+    ignore_id: EntityId<D::Entity>,
+    id_iter: WorldFetchIter<'w, <D::Entity as Entity>::FetchId<'w>, D>,
+    data_iter: WorldFetchIter<'w, J, D>,
+}
+
+impl<'w, J, D> Iterator for NestOffDiagonalIter<'w, J, D>
+where
+    J: Fetch + 'w,
+    D: WorldData + 'w,
+{
+    type Item = J::Item<'w>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let Some(mut id) = self.id_iter.next() else {
+            self.data_iter.next();
+            return None;
+        };
+
+        // At this point, `id_iter` has been advanced one more time than
+        // `data_iter`.
+
+        while id == self.ignore_id {
+            // Safety: We are viewing the entity that is to be ignored, so we
+            // must *not* call `next()` instead of `skip_one()`, since that
+            // could create an aliasing reference. Instead, we just let the
+            // pointers skip over the current entity.
+            self.data_iter.skip_one();
+
+            let next_id = self.id_iter.next();
+
+            let Some(next_id) = next_id else {
+                self.data_iter.next();
+                return None;
+            };
+
+            id = next_id;
+        }
+
+        // Safety: Again, `id_iter` has been advanced one more time than
+        // `data_iter`, and now we now know that they `id` does not point to the
+        // entity that is to be ignored, so it is safe to call `next()` on
+        // `data_iter`.
+        self.data_iter.next()
+    }
+}
+
+impl<'w, J, D> IntoIterator for NestOffDiagonal<'w, J, D>
+where
+    J: Fetch,
+    D: WorldData + 'w,
+{
+    type Item = J::Item<'w>;
+
+    type IntoIter = NestOffDiagonalIter<'w, J, D>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        // Safety: Ids cannot be mutably borrowed, so there is no invalid aliasing.
+        let id_iter = unsafe { WorldFetchIter::new(self.data) };
+
+        // Safety: TODO
+        let data_iter = unsafe { WorldFetchIter::new(self.data) };
+
+        NestOffDiagonalIter {
+            ignore_id: self.ignore_id,
+            id_iter,
+            data_iter,
+        }
+    }
+}
+
+// TODO: Size hints for iterators

--- a/src/query/nest.rs
+++ b/src/query/nest.rs
@@ -57,9 +57,9 @@ where
     J: Fetch + 'w,
     D: WorldData,
 {
-    pub(crate) data: &'w D,
-    pub(crate) query_iter: WorldFetchIter<'w, (<D::Entity as Entity>::FetchId<'w>, F), D>,
-    pub(crate) nest_fetch: D::Fetch<'w, J>,
+    data: &'w D,
+    query_iter: WorldFetchIter<'w, (<D::Entity as Entity>::FetchId<'w>, F), D>,
+    nest_fetch: D::Fetch<'w, J>,
 }
 
 impl<'w, F, J, D> Iterator for NestDataFetchIter<'w, F, J, D>

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -1,0 +1,3 @@
+pub mod column;
+pub mod query;
+pub mod world;

--- a/src/secondary/column.rs
+++ b/src/secondary/column.rs
@@ -1,7 +1,38 @@
 use std::cell::UnsafeCell;
 
+use downcast_rs::Downcast;
 use hashbrown::HashMap;
 
-use crate::EntityId;
+use crate::{Component, Entity, EntityId};
 
-pub type SecondaryColumn<E, C> = HashMap<EntityId<E>, UnsafeCell<C>>;
+pub struct SecondaryColumn<E: Entity, C>(HashMap<EntityId<E>, UnsafeCell<C>>);
+
+impl<E: Entity, C> SecondaryColumn<E, C> {
+    pub fn new() -> Self {
+        Self(Default::default())
+    }
+
+    pub fn get(&self, id: EntityId<E>) -> Option<&UnsafeCell<C>> {
+        self.0.get(&id)
+    }
+
+    pub fn insert(&mut self, id: EntityId<E>, component: C) {
+        self.0.insert(id, component.into());
+    }
+
+    pub fn remove(&mut self, id: EntityId<E>) {
+        self.0.remove(&id);
+    }
+}
+
+pub trait AnySecondaryColumn<E: Entity>: Downcast + 'static {
+    fn remove(&mut self, id: EntityId<E>);
+}
+
+downcast_rs::impl_downcast!(AnySecondaryColumn<E> where E: Entity);
+
+impl<E: Entity, C: Component> AnySecondaryColumn<E> for SecondaryColumn<E, C> {
+    fn remove(&mut self, id: EntityId<E>) {
+        self.0.remove(&id);
+    }
+}

--- a/src/secondary/column.rs
+++ b/src/secondary/column.rs
@@ -1,0 +1,7 @@
+use std::cell::UnsafeCell;
+
+use hashbrown::HashMap;
+
+use crate::EntityId;
+
+pub type SecondaryColumn<E, C> = HashMap<EntityId<E>, UnsafeCell<C>>;

--- a/src/secondary/query.rs
+++ b/src/secondary/query.rs
@@ -1,0 +1,142 @@
+use crate::{Component, Entity, EntityId, SecondaryWorld};
+
+use super::column::SecondaryColumn;
+
+pub trait SecondaryFetch<'w, E: Entity>: Copy + 'w {
+    type Item<'f>
+    where
+        Self: 'f;
+
+    fn new(world: &'w SecondaryWorld<E>) -> Option<Self>;
+
+    /// # Safety
+    ///
+    /// TODO
+    unsafe fn get<'f>(&self, id: EntityId<E>) -> Option<Self::Item<'f>>
+    where
+        Self: 'f;
+}
+
+pub trait SecondaryQuery<E: Entity> {
+    type Fetch<'w>: SecondaryFetch<'w, E>;
+}
+
+pub trait SecondaryQueryShared<E: Entity>: SecondaryQuery<E> {}
+
+pub struct ComponentFetch<'w, E: Entity, C>(&'w SecondaryColumn<E, C>);
+
+impl<'w, E: Entity, C> Clone for ComponentFetch<'w, E, C> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'w, E: Entity, C> Copy for ComponentFetch<'w, E, C> {}
+
+impl<'w, E: Entity, C: Component> SecondaryFetch<'w, E> for ComponentFetch<'w, E, C> {
+    type Item<'f> = &'f C
+    where
+        Self: 'f;
+
+    fn new(world: &'w SecondaryWorld<E>) -> Option<Self> {
+        world.column::<C>().map(ComponentFetch)
+    }
+
+    unsafe fn get<'f>(&self, id: EntityId<E>) -> Option<Self::Item<'f>>
+    where
+        Self: 'f,
+    {
+        self.0.get(&id).map(|cell| unsafe {
+            let ptr = cell.get();
+
+            &*ptr
+        })
+    }
+}
+
+impl<'q, E: Entity, C: Component> SecondaryQuery<E> for &'q C {
+    type Fetch<'w> = ComponentFetch<'w, E, C>;
+}
+
+impl<'q, E: Entity, C: Component> SecondaryQueryShared<E> for &'q C {}
+
+pub struct ComponentMutFetch<'w, E: Entity, C>(&'w SecondaryColumn<E, C>);
+
+impl<'w, E: Entity, C> Clone for ComponentMutFetch<'w, E, C> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'w, E: Entity, C> Copy for ComponentMutFetch<'w, E, C> {}
+
+impl<'w, E: Entity, C: Component> SecondaryFetch<'w, E> for ComponentMutFetch<'w, E, C> {
+    type Item<'f> = &'f mut C
+    where
+        Self: 'f;
+
+    fn new(world: &'w SecondaryWorld<E>) -> Option<Self> {
+        world.column::<C>().map(ComponentMutFetch)
+    }
+
+    unsafe fn get<'f>(&self, id: EntityId<E>) -> Option<Self::Item<'f>>
+    where
+        Self: 'f,
+    {
+        self.0.get(&id).map(|cell| unsafe {
+            let ptr = cell.get();
+
+            &mut *ptr
+        })
+    }
+}
+
+impl<'q, E: Entity, C: Component> SecondaryQuery<E> for &'q mut C {
+    type Fetch<'w> = ComponentMutFetch<'w, E, C>;
+}
+
+impl<'q, E: Entity, C: Component> SecondaryQueryShared<E> for &'q mut C {}
+
+macro_rules! tuple_impl {
+    ($($name: ident),*) => {
+        impl<'w, E: Entity, $($name: SecondaryFetch<'w, E>,)*> SecondaryFetch<'w, E>
+        for ($($name,)*) {
+            type Item<'f> = ($($name::Item<'f>,)*)
+            where
+                Self: 'f;
+
+            #[allow(unused)]
+            fn new(world: &'w SecondaryWorld<E>) -> Option<Self> {
+                Some(($($name::new(world)?,)*))
+            }
+
+            /// # Safety
+            ///
+            /// TODO
+            #[allow(unused)]
+            unsafe fn get<'f>(&self, id: EntityId<E>) -> Option<Self::Item<'f>>
+            where
+                Self: 'f,
+            {
+                #[allow(non_snake_case)]
+                let ($($name,)*) = self;
+
+                Some(($($name.get(id)?,)*))
+            }
+        }
+
+        impl<E: Entity, $($name: SecondaryQuery<E>,)*> SecondaryQuery<E> for ($($name,)*) {
+            type Fetch<'w> = ($($name::Fetch<'w>,)*);
+        }
+
+        impl<E: Entity, $($name: SecondaryQueryShared<E>,)*> SecondaryQueryShared<E>
+        for ($($name,)*) {
+        }
+    };
+}
+
+smaller_tuples_too!(
+    tuple_impl, F0, F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15
+);
+
+// TODO: With/Without

--- a/src/secondary/query.rs
+++ b/src/secondary/query.rs
@@ -49,7 +49,7 @@ impl<'w, E: Entity, C: Component> SecondaryFetch<'w, E> for ComponentFetch<'w, E
     where
         Self: 'f,
     {
-        self.0.get(&id).map(|cell| unsafe {
+        self.0.get(id).map(|cell| unsafe {
             let ptr = cell.get();
 
             &*ptr
@@ -90,7 +90,7 @@ impl<'w, E: Entity, C: Component> SecondaryFetch<'w, E> for ComponentMutFetch<'w
     where
         Self: 'f,
     {
-        self.0.get(&id).map(|cell| unsafe {
+        self.0.get(id).map(|cell| unsafe {
             let ptr = cell.get();
 
             &mut *ptr

--- a/src/secondary/world.rs
+++ b/src/secondary/world.rs
@@ -1,0 +1,35 @@
+use std::{
+    any::{Any, TypeId},
+    marker::PhantomData,
+};
+
+use hashbrown::HashMap;
+
+use crate::{Component, Entity};
+
+use super::column::SecondaryColumn;
+
+// TODO: Joining with the secondary world is currently pretty expensive, since
+// it is one hash map lookup for each entity yielded from the primary query. We
+// could try to improve this situation by having one hibitset per primary
+// archetype in the secondary world.
+
+pub struct SecondaryWorld<E: Entity>(HashMap<TypeId, Box<dyn Any>>, PhantomData<E>);
+
+impl<E: Entity> Default for SecondaryWorld<E> {
+    fn default() -> Self {
+        Self(Default::default(), PhantomData)
+    }
+}
+
+impl<E: Entity> SecondaryWorld<E> {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn column<C: Component>(&self) -> Option<&SecondaryColumn<E, C>> {
+        self.0
+            .get(&TypeId::of::<C>())
+            .and_then(|column| column.downcast_ref())
+    }
+}

--- a/src/secondary/world.rs
+++ b/src/secondary/world.rs
@@ -3,22 +3,33 @@ use std::{
     marker::PhantomData,
 };
 
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 
-use crate::{Component, Entity};
+use crate::{
+    entity::EntityVariant, query::fetch::Fetch, Component, Entity, EntityId, EntityRef, Query,
+    WorldData,
+};
 
-use super::column::SecondaryColumn;
+use super::column::{AnySecondaryColumn, SecondaryColumn};
 
 // TODO: Joining with the secondary world is currently pretty expensive, since
 // it is one hash map lookup for each entity yielded from the primary query. We
 // could try to improve this situation by having one hibitset per primary
 // archetype in the secondary world.
 
-pub struct SecondaryWorld<E: Entity>(HashMap<TypeId, Box<dyn Any>>, PhantomData<E>);
+pub struct SecondaryWorld<E: Entity> {
+    ids: HashSet<EntityId<E>>,
+    columns: HashMap<TypeId, Box<dyn AnySecondaryColumn<E>>>,
+    _phantom: PhantomData<E>,
+}
 
 impl<E: Entity> Default for SecondaryWorld<E> {
     fn default() -> Self {
-        Self(Default::default(), PhantomData)
+        Self {
+            ids: Default::default(),
+            columns: Default::default(),
+            _phantom: PhantomData,
+        }
     }
 }
 
@@ -28,8 +39,99 @@ impl<E: Entity> SecondaryWorld<E> {
     }
 
     pub fn column<C: Component>(&self) -> Option<&SecondaryColumn<E, C>> {
-        self.0
+        self.columns
             .get(&TypeId::of::<C>())
             .and_then(|column| column.downcast_ref())
     }
+
+    pub fn spawn<B: ComponentBundle<E>>(&mut self, id: EntityId<E>, components: B) -> bool {
+        if !self.ids.insert(id) {
+            return false;
+        }
+
+        self.insert(id, components);
+
+        true
+    }
+
+    pub fn despawn(&mut self, id: EntityId<E>) -> bool {
+        if !self.ids.remove(&id) {
+            return false;
+        }
+
+        for column in self.columns.values_mut() {
+            column.remove(id);
+        }
+
+        true
+    }
+
+    pub fn insert<B: ComponentBundle<E>>(&mut self, id: EntityId<E>, components: B) {
+        components.insert_entity(self, id);
+    }
+
+    // TODO: Allow removing components.
+
+    pub fn synchronize<'w>(
+        &'w mut self,
+        world: &'w E::WorldData,
+        new_entity: impl Fn(&mut Self, E::Ref<'_>),
+    ) where
+        // TODO: Can we put the bound below on `Entity` somehow?
+        <E::Ref<'w> as Query>::Fetch<'w>: Fetch<Item<'w> = EntityRef<'w, E>>,
+        E: EntityVariant<E>,
+    {
+        // FIXME: This is too inefficient for something per-frame. We need a
+        // better data structure for `SecondaryWorld` so that we do not have a
+        // linear number of hash map lookups in `synchronize`.
+
+        for (id, entity) in world.query::<(EntityId<E>, EntityRef<E>)>() {
+            if !self.ids.contains(&id) {
+                new_entity(self, entity);
+            }
+        }
+
+        let remove_ids: Vec<_> = self
+            .ids
+            .iter()
+            .copied()
+            .filter(|id| world.entity(*id).is_none())
+            .collect();
+
+        for id in remove_ids {
+            self.despawn(id);
+        }
+    }
 }
+
+pub trait ComponentBundle<E: Entity> {
+    fn insert_entity(self, world: &mut SecondaryWorld<E>, id: EntityId<E>);
+}
+
+macro_rules! tuple_impl {
+    ($($name: ident),*) => {
+        #[allow(unused)]
+        impl<E: Entity, $($name: Component,)*> ComponentBundle<E> for ($($name,)*) {
+            fn insert_entity(self, world: &mut SecondaryWorld<E>, id: EntityId<E>) {
+                #[allow(non_snake_case)]
+                let ($($name,)*) = self;
+
+                $(
+                    let column = world
+                        .columns
+                        .entry(TypeId::of::<$name>())
+                        .or_insert(Box::new(SecondaryColumn::<E, $name>::new()));
+
+                    let column: &mut SecondaryColumn<E, $name> =
+                        column.downcast_mut().expect("Bug in SecondaryWorld");
+
+                    column.insert(id, $name);
+                )*
+            }
+        }
+    };
+}
+
+smaller_tuples_too!(
+    tuple_impl, F0, F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15
+);

--- a/src/world.rs
+++ b/src/world.rs
@@ -59,6 +59,16 @@ pub trait WorldData: Default + Sized + 'static {
         unsafe { fetch.get(id.get()) }
     }
 
+    fn get_mut<Q: Query>(
+        &mut self,
+        id: EntityId<Self::Entity>,
+    ) -> Option<<Q::Fetch<'_> as Fetch>::Item<'_>> {
+        let fetch = self.fetch::<<Q as Query>::Fetch<'_>>();
+
+        // Safety: TODO
+        unsafe { fetch.get(id.get()) }
+    }
+
     fn entity<'w, E>(&'w self, id: EntityId<E>) -> Option<EntityRef<'w, E>>
     where
         E: EntityVariant<Self::Entity>,


### PR DESCRIPTION
This is the idea:

- For pure game logic, use an `enum Entity`, i.e. a world with static archetypes.
- For rendering state, audio state, etc., have a `SecondaryWorld<Entity>` next to that.
- For querying the worlds together, join them via `EntityId<Entity>`.

The secondary world is sparse and allows components to be added dynamically.

Contrived example:
```rust
for (position, (render, cube)) in world
    .query::<&Position>()
    .join::<(&Render, &Cube)>(&secondary_world)
{
    // Render the entity
}
```

The hope is that this will give us the best of both worlds: the game logic has statically known entity types as well as the ability to destructure with `match`. However, for visualizing the game state, we maintain the flexibility of classic ECS approaches, i.e. we can attach arbitrary components. As a bonus, this neatly separates game logic from visualization.

The PR is completely untested. It also uses inefficent data structures: it performs hash map lookups for each joined entity during query processing and `synchronize()` performs a linear number of hash map lookups.