### PR TITLE
Clone all the things

### DIFF
--- a/derive/src/query.rs
+++ b/derive/src/query.rs
@@ -46,7 +46,7 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
     Ok(quote! {
         // Fetch
 
-        #[allow(unused)]
+        #[allow(unused, non_snake_case)]
         #[derive(::std::clone::Clone, ::std::marker::Copy)]
         #vis struct #ident_fetch<#lifetime> {
             __stecs__len: usize,

--- a/examples/game.rs
+++ b/examples/game.rs
@@ -11,13 +11,13 @@ impl Position {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Velocity(i32);
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Health(i32);
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Target(Option<EntityId<Entity>>);
 
 // Entities

--- a/examples/game.rs
+++ b/examples/game.rs
@@ -22,14 +22,14 @@ struct Target(Option<EntityId<Entity>>);
 
 // Entities
 
-#[derive(stecs::Entity)]
+#[derive(stecs::Entity, Clone)]
 struct Player {
     pos: Position,
     vel: Velocity,
     health: Health,
 }
 
-#[derive(stecs::Entity)]
+#[derive(stecs::Entity, Clone)]
 struct Enemy {
     pos: Position,
     vel: Velocity,
@@ -37,7 +37,7 @@ struct Enemy {
     target: Target,
 }
 
-#[derive(stecs::Entity)]
+#[derive(stecs::Entity, Clone)]
 struct Bullet {
     pos: Position,
     vel: Velocity,
@@ -47,7 +47,7 @@ struct Bullet {
 // World
 
 // Define your world by declaring an enum that contains all the entity variants:
-#[derive(stecs::Entity)]
+#[derive(stecs::Entity, Clone)]
 enum Entity {
     Player(Player),
     Enemy(Enemy),

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -1,4 +1,7 @@
+#[derive(Clone)]
 pub struct Position(f32);
+
+#[derive(Clone)]
 pub struct Velocity(f32);
 
 #[derive(stecs::Query)]

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -9,7 +9,7 @@ use crate::{
     WorldData,
 };
 
-pub trait Columns: Default + 'static {
+pub trait Columns: Default + Clone + 'static {
     type Entity: Entity<Id = EntityKey<Self::Entity>> + EntityVariant<Self::Entity>;
 
     fn column<C: Component>(&self) -> Option<&RefCell<Column<C>>>;
@@ -32,7 +32,7 @@ pub trait Columns: Default + 'static {
 pub trait Entity: Clone + 'static {
     type Id: Copy + Debug + Eq + Ord + Hash + 'static;
 
-    type Ref<'f>: QueryShared;
+    type Ref<'f>: QueryShared + Clone;
     /*where
     for<'w> <Self::Ref<'w> as Query>::Fetch<'w>: Fetch<Item<'w> = Self::Ref<'w>>;*/
 
@@ -47,6 +47,8 @@ pub trait Entity: Clone + 'static {
     type FetchId<'w>: Fetch<Item<'w> = EntityId<Self>>;
 
     type WorldData: WorldData<Entity = Self>;
+
+    fn from_ref<'f>(entity: Self::Ref<'f>) -> Self;
 }
 
 pub trait EntityStruct: Entity {

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -29,7 +29,7 @@ pub trait Columns: Default + 'static {
         'w: 'f;
 }
 
-pub trait Entity: Sized + 'static {
+pub trait Entity: Clone + 'static {
     type Id: Copy + Debug + Eq + Ord + Hash + 'static;
 
     type Ref<'f>: QueryShared;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,6 @@ pub use self::{
     secondary::{query::SecondaryQuery, query::SecondaryQueryShared, world::SecondaryWorld},
     world::{World, WorldData},
 };
-pub trait Component: 'static {}
+pub trait Component: Clone + 'static {}
 
-impl<T> Component for T where T: 'static {}
+impl<T> Component for T where T: Clone + 'static {}

--- a/src/world.rs
+++ b/src/world.rs
@@ -20,7 +20,7 @@ pub trait WorldFetch<'w, D: WorldData>: Clone {
     fn filter_by_outer<DOuter: WorldData>(&mut self) {}
 }
 
-pub trait WorldData: Default + Sized + 'static {
+pub trait WorldData: Default + Clone + 'static {
     type Entity: EntityVariant<Self::Entity>;
 
     type Fetch<'w, F: Fetch + 'w>: WorldFetch<'w, Self, Fetch = F>;


### PR DESCRIPTION
This PR places a strong requirement on impls of `Component` and `Entity`: they must be `Clone`-able!

As a result, we can add `Entity::from_ref`, which should be useful for serialization.