### PR TITLE
Rename `EntityId` to just `Id`

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -7,7 +7,7 @@ use std::{
 
 use bencher::{benchmark_group, benchmark_main, Bencher};
 
-use stecs::{EntityId, World};
+use stecs::{Id, World};
 
 #[derive(Clone)]
 struct Position(f32);
@@ -42,7 +42,7 @@ fn iterate_100k(b: &mut Bencher) {
     }
 
     b.iter(|| {
-        for (_, pos, vel) in world.query_mut::<(EntityId<Bundle>, &mut Position, &Velocity)>() {
+        for (_, pos, vel) in world.query_mut::<(Id<Bundle>, &mut Position, &Velocity)>() {
             pos.0 += vel.0;
         }
     })
@@ -70,7 +70,7 @@ fn iterate_100k_random_access(b: &mut Bencher) {
     struct Enemy {
         pos: Position,
         vel: Velocity,
-        target: EntityId<Entity>,
+        target: Id<Entity>,
     }
 
     #[derive(stecs::Entity)]
@@ -113,7 +113,7 @@ fn iterate_100k_random_access(b: &mut Bencher) {
 
     b.iter(|| {
         let (query_a, query_b) =
-            world.queries_mut::<((&EntityId<Entity>, &Position, &mut Velocity), &Position)>();
+            world.queries_mut::<((&Id<Entity>, &Position, &mut Velocity), &Position)>();
 
         for (target_a, pos_a, vel_a) in query_a {
             let pos_b = query_b.get(*target_a).unwrap();

--- a/derive/src/entity/enum.rs
+++ b/derive/src/entity/enum.rs
@@ -124,7 +124,7 @@ pub fn derive(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream2> {
                     #ident::#variant_idents(self)
                 }
 
-                fn spawn(self, data: &mut #ident_world_data) -> ::stecs::EntityId<Self> {
+                fn spawn(self, data: &mut #ident_world_data) -> ::stecs::Id<Self> {
                     use ::stecs::WorldData;
 
                     data.#variant_idents.spawn(self)
@@ -149,7 +149,7 @@ pub fn derive(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream2> {
                 self
             }
 
-            fn spawn(self, data: &mut #ident_world_data) -> ::stecs::EntityId<Self> {
+            fn spawn(self, data: &mut #ident_world_data) -> ::stecs::Id<Self> {
                 use ::stecs::WorldData;
 
                 match self {
@@ -218,7 +218,7 @@ pub fn derive(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream2> {
             type Entity = #ident;
             type Fetch<'w, F: ::stecs::query::fetch::Fetch + 'w> = #ident_world_fetch<'w, F>;
 
-            fn spawn<E>(&mut self, entity: E) -> ::stecs::EntityId<E>
+            fn spawn<E>(&mut self, entity: E) -> ::stecs::Id<E>
             where
                 E: ::stecs::entity::EntityVariant<#ident>,
             {
@@ -227,7 +227,7 @@ pub fn derive(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream2> {
 
             fn despawn<E>(
                 &mut self,
-                id: ::stecs::EntityId<E>,
+                id: ::stecs::Id<E>,
             ) -> ::std::option::Option<Self::Entity>
             where
                 E: ::stecs::entity::EntityVariant<Self::Entity>,
@@ -236,7 +236,7 @@ pub fn derive(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream2> {
                     #(
                         #ident_id::#variant_idents(id) => {
                             self.#variant_idents
-                                .despawn(::stecs::EntityId::<#variant_tys>::new(id))
+                                .despawn(::stecs::Id::<#variant_tys>::new(id))
                                 .map(|entity| #ident::#variant_idents(entity))
                         }
                     )*
@@ -245,27 +245,27 @@ pub fn derive(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream2> {
 
             fn spawn_at(
                 &mut self,
-                id: ::stecs::EntityId<Self::Entity>,
+                id: ::stecs::Id<Self::Entity>,
                 entity: Self::Entity,
             ) -> ::std::option::Option<Self::Entity> {
                 match (id.get(), entity) {
                     #(
                         (#ident_id::#variant_idents(id), #ident::#variant_idents(entity)) => {
                             self.#variant_idents
-                                .spawn_at(::stecs::EntityId::new(id), entity)
+                                .spawn_at(::stecs::Id::new(id), entity)
                                 .map(#ident::#variant_idents)
                         }
                     )*
-                    _ => panic!("Incompatible EntityId and Entity variants in `spawn_at`"),
+                    _ => panic!("Incompatible Id and Entity variants in `spawn_at`"),
                 }
             }
 
-            fn contains(&self, id: ::stecs::EntityId<Self::Entity>) -> bool {
+            fn contains(&self, id: ::stecs::Id<Self::Entity>) -> bool {
                 match id.get() {
                     #(
                         #ident_id::#variant_idents(id) => {
                             self.#variant_idents
-                                .contains(::stecs::EntityId::<#variant_tys>::new(id))
+                                .contains(::stecs::Id::<#variant_tys>::new(id))
                         }
                     )*
                 }
@@ -354,7 +354,7 @@ pub fn derive(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream2> {
         }
 
         unsafe impl<'w> ::stecs::query::fetch::Fetch for #ident_id_fetch<'w> {
-            type Item<'a> = ::stecs::EntityId<#ident> where Self: 'a;
+            type Item<'a> = ::stecs::Id<#ident> where Self: 'a;
 
             fn new<A: ::stecs::entity::Columns>(
                 ids: &::stecs::column::Column<::stecs::thunderdome::Index>,
@@ -380,7 +380,7 @@ pub fn derive(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream2> {
             where
                 Self: 'a,
             {
-                ::stecs::EntityId::new(match self {
+                ::stecs::Id::new(match self {
                     #(
                         #ident_id_fetch::#variant_idents(fetch) =>
                             #ident_id::#variant_idents(fetch.get(index).get()),

--- a/derive/src/entity/struct.rs
+++ b/derive/src/entity/struct.rs
@@ -150,7 +150,7 @@ pub fn derive(input: &DeriveInput, fields: &syn::FieldsNamed) -> Result<TokenStr
                 self
             }
 
-            fn spawn(self, data: &mut Self::WorldData) -> ::stecs::EntityId<Self> {
+            fn spawn(self, data: &mut Self::WorldData) -> ::stecs::Id<Self> {
                 use ::stecs::WorldData;
 
                 data.spawn(self)

--- a/examples/brainstorm.rs
+++ b/examples/brainstorm.rs
@@ -1,7 +1,7 @@
 use std::iter::ExactSizeIterator;
 
 use serde::{Deserialize, Serialize};
-use stecs::{entity::EntityVariant, Component, EntityId, EntityRef, EntityRefMut};
+use stecs::{entity::EntityVariant, Component, EntityRef, EntityRefMut, Id};
 
 #[derive(Clone, Serialize, Deserialize)]
 struct Position(f32);
@@ -28,7 +28,7 @@ struct Boier<T: Component, S: Component> {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-struct Target(EntityId<Entity>);
+struct Target(Id<Entity>);
 
 #[derive(stecs::Entity, Clone, Serialize, Deserialize)]
 struct Enemy {
@@ -39,13 +39,13 @@ struct Enemy {
 #[derive(stecs::Entity, Clone, Serialize, Deserialize)]
 struct Enemy2 {
     pos: Position,
-    targets: Vec<EntityId<Entity>>,
+    targets: Vec<Id<Entity>>,
 }
 
 #[derive(stecs::Entity, Clone, Serialize, Deserialize)]
 struct InnerEnemy {
     pos: Position,
-    targets: Vec<EntityId<Entity>>,
+    targets: Vec<Id<Entity>>,
 }
 
 #[derive(stecs::Entity, Clone, Serialize, Deserialize)]
@@ -76,8 +76,8 @@ type World = stecs::World<Entity>;
 /*
 #[derive(Serialize, Deserialize)]
 pub struct SerDeThing {
-    id: EntityId<Player>,
-    id2: EntityId<Entity>,
+    id: Id<Player>,
+    id2: Id<Entity>,
 }
 */
 
@@ -162,7 +162,7 @@ fn main() {
     }
 
     println!("PhysicsObject");
-    for (id, q) in world.query_mut::<(EntityId<Entity>, PhysicsObject)>() {
+    for (id, q) in world.query_mut::<(Id<Entity>, PhysicsObject)>() {
         println!("{:?}: {:?} {:?}", id, q.position.0, q.velocity.0);
     }
 
@@ -214,22 +214,22 @@ fn main() {
         dbg!(p.0, q.0);
     }
 
-    println!("EntityId, Position");
-    for (id, _) in world.query_mut::<(EntityId<Entity>, &Position)>() {
+    println!("Id, Position");
+    for (id, _) in world.query_mut::<(Id<Entity>, &Position)>() {
         dbg!(id);
     }
 
-    println!("EntityId, Position, With<Target>");
+    println!("Id, Position, With<Target>");
     for (id, pos) in world
-        .query_mut::<(EntityId<Entity>, &Position)>()
+        .query_mut::<(Id<Entity>, &Position)>()
         .with::<&Target>()
     {
         dbg!(id, pos.0);
     }
 
-    println!("EntityId, Position, Without<Target>");
+    println!("Id, Position, Without<Target>");
     for (id, pos) in world
-        .query_mut::<(EntityId<Entity>, &Position)>()
+        .query_mut::<(Id<Entity>, &Position)>()
         .without::<&Target>()
     {
         dbg!(id, pos.0);
@@ -237,19 +237,19 @@ fn main() {
 
     println!("len");
     dbg!(world
-        .query_mut::<(EntityId<Entity>, &Position)>()
+        .query_mut::<(Id<Entity>, &Position)>()
         .without::<&Target>()
         .into_iter()
         .len());
 
-    println!("EntityId, Target");
-    for (id, target) in world.query_mut::<(EntityId<Entity>, &Target)>() {
+    println!("Id, Target");
+    for (id, target) in world.query_mut::<(Id<Entity>, &Target)>() {
         println!("{:?} targeting {:?}", id, target);
     }
 
-    println!("EntityId, Target, nest with Position");
+    println!("Id, Target, nest with Position");
     for ((id, target), mut nest) in world
-        .query_mut::<(EntityId<Entity>, &Target)>()
+        .query_mut::<(Id<Entity>, &Target)>()
         .nest::<&mut Position>()
     {
         let Some(target_pos) = nest.get_mut(target.0) else {
@@ -263,10 +263,10 @@ fn main() {
         //println!("{:?} targeting {:?} @ {:?}", id, target, target_pos_2.0);
     }
 
-    println!("EntityId, Target, nest with Position as EntityRefMut");
+    println!("Id, Target, nest with Position as EntityRefMut");
 
     for ((id, target), mut nest) in world
-        .query_mut::<(EntityId<Entity>, &Target)>()
+        .query_mut::<(Id<Entity>, &Target)>()
         .nest::<EntityRefMut<Player>>()
     {
         let Some(target_pos) = nest.get_mut(target.0) else {
@@ -301,8 +301,8 @@ fn main() {
     }*/
 
     let (positions_and_velocities, positions_b) = world.queries_mut::<(
-        (EntityId<Entity>, &Position, &mut Velocity),
-        (EntityId<Entity>, &Position),
+        (Id<Entity>, &Position, &mut Velocity),
+        (Id<Entity>, &Position),
     )>();
     for (id_a, position_a, velocity) in positions_and_velocities {
         for (id_b, position_b) in &positions_b {
@@ -384,19 +384,19 @@ fn main() {
         }
     }
 
-    for key in world.query_mut::<EntityId<Enemy>>() {
+    for key in world.query_mut::<Id<Enemy>>() {
         println!("got enemy: {:?}", key);
     }
 
-    for id in world.query_mut::<EntityId<Entity>>() {
+    for id in world.query_mut::<Id<Entity>>() {
         println!("got id: {:?}", id);
     }
 
     println!("Fetch aliasing check");
 
     for ((id, enemy), nest) in world
-        .query_mut::<(EntityId<Entity>, EntityRefMut<Enemy2>)>()
-        .nest::<(EntityId<Entity>, &mut Position)>()
+        .query_mut::<(Id<Entity>, EntityRefMut<Enemy2>)>()
+        .nest::<(Id<Entity>, &mut Position)>()
     {
         for (id2, p) in nest {
             println!("{:?} {:?} {} {}", id, id2, p.0, enemy.pos.0);

--- a/examples/flat.rs
+++ b/examples/flat.rs
@@ -1,4 +1,4 @@
-use stecs::{CloneEntityFromRef, EntityId};
+use stecs::{CloneEntityFromRef, Id};
 
 #[derive(stecs::Entity, Clone)]
 #[stecs(derive_columns(Clone))]
@@ -37,13 +37,13 @@ fn main() {
         },
     });
 
-    for id in world.query::<EntityId<Entity>>().with::<(&f32, &i32)>() {
+    for id in world.query::<Id<Entity>>().with::<(&f32, &i32)>() {
         dbg!(id);
     }
 
     let entity_ref = world.entity(id).unwrap();
     let _ = Bullet::clone_entity_from_ref(entity_ref);
 
-    let entity_ref = world.entity(EntityId::<Entity>::from(id)).unwrap();
+    let entity_ref = world.entity(Id::<Entity>::from(id)).unwrap();
     let _ = Entity::clone_entity_from_ref(entity_ref);
 }

--- a/examples/game.rs
+++ b/examples/game.rs
@@ -1,4 +1,4 @@
-use stecs::{EntityId, EntityRef, EntityRefMut};
+use stecs::{EntityRef, EntityRefMut, Id};
 
 // Components
 
@@ -18,7 +18,7 @@ struct Velocity(i32);
 struct Health(i32);
 
 #[derive(Debug, Clone)]
-struct Target(Option<EntityId<Entity>>);
+struct Target(Option<Id<Entity>>);
 
 // Entities
 
@@ -41,7 +41,7 @@ struct Enemy {
 struct Bullet {
     pos: Position,
     vel: Velocity,
-    owner: EntityId<Entity>,
+    owner: Id<Entity>,
 }
 
 // World
@@ -100,7 +100,7 @@ fn align_to_target(world: &mut World) {
     // Acquire targets.
     for ((pos, target), nest) in world
         .query_mut::<(&Position, &mut Target)>()
-        .nest::<(EntityId<Player>, EntityRef<Player>)>()
+        .nest::<(Id<Player>, EntityRef<Player>)>()
     {
         if target.0.is_some() {
             continue;
@@ -136,7 +136,7 @@ fn align_to_target(world: &mut World) {
 
 fn spawn_bullets(world: &mut World) {
     let bullets: Vec<_> = world
-        .query::<(EntityId<Entity>, &Position, &Velocity)>()
+        .query::<(Id<Entity>, &Position, &Velocity)>()
         .with::<&Target>()
         .into_iter()
         .map(|(id, pos, vel)| Bullet {
@@ -155,7 +155,7 @@ fn update_bullets(world: &mut World) {
     for (bullet, nest) in
         world
             .query_mut::<EntityRefMut<Bullet>>()
-            .nest::<(EntityId<Entity>, &Position, &mut Health)>()
+            .nest::<(Id<Entity>, &Position, &mut Health)>()
     {
         // For performance reasons, this check would usually be done with
         // a spatial acceleration structure rather than an inner loop.
@@ -170,7 +170,7 @@ fn update_bullets(world: &mut World) {
 
 fn despawn_dead(world: &mut World) {
     let dead: Vec<_> = world
-        .query::<(EntityId<Entity>, &Health)>()
+        .query::<(Id<Entity>, &Health)>()
         .into_iter()
         .filter(|(_, health)| health.0 <= 0)
         .map(|(id, _)| id)

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -33,7 +33,7 @@ pub trait Entity: Sized + 'static {
     type WorldData: WorldData<Entity = Self>;
 
     #[doc(hidden)]
-    type FetchId<'w>: Fetch<Item<'w> = EntityId<Self>> + 'w;
+    type FetchId<'w>: Fetch<Item<'w> = Id<Self>> + 'w;
 
     #[doc(hidden)]
     type Fetch<'w>: Fetch<Item<'w> = Self::Borrow<'w>> + 'w;
@@ -57,7 +57,7 @@ pub trait EntityStruct: Entity {
 pub trait EntityVariant<EOuter: Entity>: Entity {
     fn into_outer(self) -> EOuter;
 
-    fn spawn(self, data: &mut EOuter::WorldData) -> EntityId<Self>;
+    fn spawn(self, data: &mut EOuter::WorldData) -> Id<Self>;
 
     fn id_to_outer(id: Self::Id) -> EOuter::Id
     where
@@ -87,14 +87,14 @@ pub type EntityColumns<E> = <E as EntityStruct>::Columns;
     Debug(bound = "")
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct EntityId<E: Entity>(E::Id);
+pub struct Id<E: Entity>(E::Id);
 
-impl<E: Entity> EntityId<E> {
+impl<E: Entity> Id<E> {
     pub fn new(id: E::Id) -> Self {
         Self(id)
     }
 
-    pub fn from<EInner: EntityVariant<E>>(id: EntityId<EInner>) -> Self {
+    pub fn from<EInner: EntityVariant<E>>(id: Id<EInner>) -> Self {
         id.to_outer()
     }
 
@@ -102,19 +102,19 @@ impl<E: Entity> EntityId<E> {
         self.0
     }
 
-    pub fn to_outer<EOuter>(self) -> EntityId<EOuter>
+    pub fn to_outer<EOuter>(self) -> Id<EOuter>
     where
         EOuter: Entity,
         E: EntityVariant<EOuter>,
     {
-        EntityId(E::id_to_outer(self.0))
+        Id(E::id_to_outer(self.0))
     }
 
-    pub fn try_to_inner<EInner>(self) -> Option<EntityId<EInner>>
+    pub fn try_to_inner<EInner>(self) -> Option<Id<EInner>>
     where
         EInner: EntityVariant<E>,
     {
-        EInner::try_id_from_outer(self.0).map(EntityId::new)
+        EInner::try_id_from_outer(self.0).map(Id::new)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use stecs_derive::{Entity, Query, QueryShared};
 
 #[doc(inline)]
 pub use self::{
-    entity::{CloneEntityFromRef, CloneEntityIntoRef, Entity, EntityId, EntityRef, EntityRefMut},
+    entity::{CloneEntityFromRef, CloneEntityIntoRef, Entity, EntityRef, EntityRefMut, Id},
     query::{Or, Query, QueryShared, With, Without},
     secondary::{query::SecondaryQuery, query::SecondaryQueryShared, world::SecondaryWorld},
     world::{World, WorldData},

--- a/src/query.rs
+++ b/src/query.rs
@@ -10,7 +10,7 @@ use crate::{
     column::{ColumnRawParts, ColumnRawPartsMut},
     entity::EntityVariant,
     world::WorldFetch,
-    Component, Entity, EntityId, SecondaryQuery, SecondaryQueryShared, SecondaryWorld, WorldData,
+    Component, Entity, Id, SecondaryQuery, SecondaryQueryShared, SecondaryWorld, WorldData,
 };
 
 use self::{
@@ -49,13 +49,13 @@ unsafe impl<'q, C: Component> Query for &'q mut C {
     }
 }
 
-unsafe impl<E: Entity> Query for EntityId<E> {
+unsafe impl<E: Entity> Query for Id<E> {
     type Fetch<'w> = E::FetchId<'w>;
 
     fn for_each_borrow(_: impl FnMut(TypeId, bool)) {}
 }
 
-unsafe impl<E: Entity> QueryShared for EntityId<E> {}
+unsafe impl<E: Entity> QueryShared for Id<E> {}
 
 macro_rules! tuple_impl {
     () => {
@@ -314,7 +314,7 @@ where
     }
 
     #[inline]
-    pub fn get_mut<'a, E>(&'a mut self, id: EntityId<E>) -> Option<QueryItem<'w, 'a, Q>>
+    pub fn get_mut<'a, E>(&'a mut self, id: Id<E>) -> Option<QueryItem<'w, 'a, Q>>
     where
         'w: 'a,
         E: EntityVariant<D::Entity>,
@@ -332,7 +332,7 @@ where
     D: WorldData,
 {
     #[inline]
-    pub fn get<'a, E>(&'a self, id: EntityId<E>) -> Option<QueryItem<'w, 'a, Q>>
+    pub fn get<'a, E>(&'a self, id: Id<E>) -> Option<QueryItem<'w, 'a, Q>>
     where
         'w: 'a,
         E: EntityVariant<D::Entity>,
@@ -401,7 +401,7 @@ where
     }
 
     #[inline]
-    pub fn get_mut<'a, E>(&'a mut self, id: EntityId<E>) -> Option<QueryItem<'w, 'a, Q>>
+    pub fn get_mut<'a, E>(&'a mut self, id: Id<E>) -> Option<QueryItem<'w, 'a, Q>>
     where
         'w: 'a,
         E: EntityVariant<D::Entity>,
@@ -423,7 +423,7 @@ where
     D: WorldData,
 {
     #[inline]
-    pub fn get<'a, E>(&'a self, id: EntityId<E>) -> Option<QueryItem<'w, 'a, Q>>
+    pub fn get<'a, E>(&'a self, id: Id<E>) -> Option<QueryItem<'w, 'a, Q>>
     where
         'w: 'a,
         E: EntityVariant<D::Entity>,

--- a/src/query/fetch.rs
+++ b/src/query/fetch.rs
@@ -4,7 +4,7 @@ use crate::{
     archetype::EntityKey,
     column::{Column, ColumnRawParts, ColumnRawPartsMut},
     entity::{Columns, EntityStruct},
-    Component, EntityId,
+    Component, Id,
 };
 
 use super::Or;
@@ -108,7 +108,7 @@ unsafe impl<E> Fetch for EntityKeyFetch<E>
 where
     E: EntityStruct<Id = EntityKey<E>>,
 {
-    type Item<'a> = EntityId<E>;
+    type Item<'a> = Id<E>;
 
     fn new<T: Columns>(ids: &Column<thunderdome::Index>, _: &T) -> Option<Self> {
         if TypeId::of::<T::Entity>() == TypeId::of::<E>() {
@@ -128,7 +128,7 @@ where
     where
         Self: 'a,
     {
-        EntityId::new(EntityKey::new_unchecked(*Fetch::get(&self.0, index)))
+        Id::new(EntityKey::new_unchecked(*Fetch::get(&self.0, index)))
     }
 }
 

--- a/src/query/join.rs
+++ b/src/query/join.rs
@@ -4,7 +4,7 @@ use crate::{
     entity::EntityVariant,
     secondary::query::{SecondaryFetch, SecondaryQueryItem},
     world::WorldFetch,
-    Entity, EntityId, Query, QueryShared, SecondaryQuery, SecondaryQueryShared, SecondaryWorld,
+    Entity, Id, Query, QueryShared, SecondaryQuery, SecondaryQueryShared, SecondaryWorld,
     WorldData,
 };
 
@@ -78,7 +78,7 @@ where
     #[inline]
     pub fn get<'a, E>(
         &'a self,
-        id: EntityId<E>,
+        id: Id<E>,
     ) -> Option<(
         QueryItem<'w, 'a, Q>,
         SecondaryQueryItem<'w, 'a, J, D::Entity>,
@@ -106,7 +106,7 @@ where
     #[inline]
     pub fn get_mut<'a, E>(
         &'a mut self,
-        id: EntityId<E>,
+        id: Id<E>,
     ) -> Option<(
         QueryItem<'w, 'a, Q>,
         SecondaryQueryItem<'w, 'a, J, D::Entity>,

--- a/src/query/nest.rs
+++ b/src/query/nest.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::{entity::EntityVariant, world::WorldFetch, Entity, EntityId, Query, WorldData};
+use crate::{entity::EntityVariant, world::WorldFetch, Entity, Id, Query, WorldData};
 
 use super::{
     assert_borrow, fetch::Fetch, iter::WorldFetchIter, nest2::Nest2QueryBorrow, QueryItem,
@@ -47,7 +47,7 @@ where
     #[inline]
     pub fn get_mut<'a, E>(
         &'a mut self,
-        id: EntityId<E>,
+        id: Id<E>,
     ) -> Option<(QueryItem<'w, 'a, Q>, Nest<'w, J::Fetch<'w>, D>)>
     where
         'w: 'a,
@@ -107,7 +107,7 @@ where
     D: WorldData + 'w,
 {
     pub(crate) data: &'w D,
-    pub(crate) ignore_id: EntityId<D::Entity>,
+    pub(crate) ignore_id: Id<D::Entity>,
     pub(crate) world_fetch_j: D::Fetch<'w, J>,
 }
 
@@ -152,7 +152,7 @@ where
     // Rust's borrowing rules if `J` contains an exclusive borrow, since `get()`
     // could be called multiple times with the same `id`.
     #[inline]
-    pub fn get_mut<'a, E>(&'a mut self, id: EntityId<E>) -> Option<J::Item<'a>>
+    pub fn get_mut<'a, E>(&'a mut self, id: Id<E>) -> Option<J::Item<'a>>
     where
         'w: 'a,
         E: EntityVariant<D::Entity>,
@@ -176,7 +176,7 @@ where
     J: Fetch + 'w,
     D: WorldData + 'w,
 {
-    ignore_id: EntityId<D::Entity>,
+    ignore_id: Id<D::Entity>,
     iter_id: WorldFetchIter<'w, <D::Entity as Entity>::FetchId<'w>, D>,
     iter_j: WorldFetchIter<'w, J, D>,
 }

--- a/src/query/nest2.rs
+++ b/src/query/nest2.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::{entity::EntityVariant, world::WorldFetch, Entity, EntityId, Query, WorldData};
+use crate::{entity::EntityVariant, world::WorldFetch, Entity, Id, Query, WorldData};
 
 use super::{fetch::Fetch, iter::WorldFetchIter};
 
@@ -15,7 +15,7 @@ where
     D: WorldData + 'w,
 {
     pub(crate) data: &'w D,
-    pub(crate) ignore_ids: [EntityId<D::Entity>; 2],
+    pub(crate) ignore_ids: [Id<D::Entity>; 2],
     pub(crate) fetch1: D::Fetch<'w, J1>,
 }
 
@@ -26,7 +26,7 @@ where
     D: WorldData + 'w,
 {
     pub(crate) data: &'w D,
-    pub(crate) ignore_id: EntityId<D::Entity>,
+    pub(crate) ignore_id: Id<D::Entity>,
     pub(crate) fetch0: D::Fetch<'w, J0>,
     pub(crate) fetch1: D::Fetch<'w, J1>,
 }
@@ -106,7 +106,7 @@ where
     // Rust's borrowing rules if `J0` contains an exclusive borrow, since
     // `get()` could be called multiple times with the same `id`.
     #[inline]
-    pub fn get_mut<'a, E>(&'a mut self, id: EntityId<E>) -> Option<(J0::Item<'a>, Nest1<'w, J1, D>)>
+    pub fn get_mut<'a, E>(&'a mut self, id: Id<E>) -> Option<(J0::Item<'a>, Nest1<'w, J1, D>)>
     where
         'w: 'a,
         E: EntityVariant<D::Entity>,
@@ -140,7 +140,7 @@ where
     // Rust's borrowing rules if `J1` contains an exclusive borrow, since
     // `get()` could be called multiple times with the same `id`.
     #[inline]
-    pub fn get_mut<'a, E>(&'a mut self, id: EntityId<E>) -> Option<J1::Item<'a>>
+    pub fn get_mut<'a, E>(&'a mut self, id: Id<E>) -> Option<J1::Item<'a>>
     where
         'w: 'a,
         E: EntityVariant<D::Entity>,

--- a/src/secondary/column.rs
+++ b/src/secondary/column.rs
@@ -3,9 +3,9 @@ use std::cell::UnsafeCell;
 use downcast_rs::Downcast;
 use fxhash::FxHashMap;
 
-use crate::{Component, Entity, EntityId};
+use crate::{Component, Entity, Id};
 
-pub struct SecondaryColumn<E: Entity, C>(FxHashMap<EntityId<E>, UnsafeCell<C>>);
+pub struct SecondaryColumn<E: Entity, C>(FxHashMap<Id<E>, UnsafeCell<C>>);
 
 impl<E: Entity, C> Default for SecondaryColumn<E, C> {
     fn default() -> Self {
@@ -18,27 +18,27 @@ impl<E: Entity, C> SecondaryColumn<E, C> {
         Default::default()
     }
 
-    pub fn get(&self, id: EntityId<E>) -> Option<&UnsafeCell<C>> {
+    pub fn get(&self, id: Id<E>) -> Option<&UnsafeCell<C>> {
         self.0.get(&id)
     }
 
-    pub fn insert(&mut self, id: EntityId<E>, component: C) {
+    pub fn insert(&mut self, id: Id<E>, component: C) {
         self.0.insert(id, component.into());
     }
 
-    pub fn remove(&mut self, id: EntityId<E>) {
+    pub fn remove(&mut self, id: Id<E>) {
         self.0.remove(&id);
     }
 }
 
 pub trait AnySecondaryColumn<E: Entity>: Downcast + 'static {
-    fn remove(&mut self, id: EntityId<E>);
+    fn remove(&mut self, id: Id<E>);
 }
 
 downcast_rs::impl_downcast!(AnySecondaryColumn<E> where E: Entity);
 
 impl<E: Entity, C: Component> AnySecondaryColumn<E> for SecondaryColumn<E, C> {
-    fn remove(&mut self, id: EntityId<E>) {
+    fn remove(&mut self, id: Id<E>) {
         self.0.remove(&id);
     }
 }

--- a/src/secondary/query.rs
+++ b/src/secondary/query.rs
@@ -1,6 +1,6 @@
 use std::any::TypeId;
 
-use crate::{Component, Entity, EntityId, SecondaryWorld};
+use crate::{Component, Entity, Id, SecondaryWorld};
 
 use super::column::SecondaryColumn;
 
@@ -14,7 +14,7 @@ pub trait SecondaryFetch<'w, E: Entity>: Copy + 'w {
     /// # Safety
     ///
     /// TODO
-    unsafe fn get<'a>(&self, id: EntityId<E>) -> Option<Self::Item<'a>>
+    unsafe fn get<'a>(&self, id: Id<E>) -> Option<Self::Item<'a>>
     where
         Self: 'a;
 }
@@ -50,7 +50,7 @@ impl<'w, E: Entity, C: Component> SecondaryFetch<'w, E> for ComponentFetch<'w, E
         world.column::<C>().map(ComponentFetch)
     }
 
-    unsafe fn get<'a>(&self, id: EntityId<E>) -> Option<Self::Item<'a>>
+    unsafe fn get<'a>(&self, id: Id<E>) -> Option<Self::Item<'a>>
     where
         Self: 'a,
     {
@@ -91,7 +91,7 @@ impl<'w, E: Entity, C: Component> SecondaryFetch<'w, E> for ComponentMutFetch<'w
         world.column::<C>().map(ComponentMutFetch)
     }
 
-    unsafe fn get<'a>(&self, id: EntityId<E>) -> Option<Self::Item<'a>>
+    unsafe fn get<'a>(&self, id: Id<E>) -> Option<Self::Item<'a>>
     where
         Self: 'a,
     {
@@ -130,7 +130,7 @@ macro_rules! tuple_impl {
             ///
             /// TODO
             #[allow(unused)]
-            unsafe fn get<'a>(&self, id: EntityId<E>) -> Option<Self::Item<'a>>
+            unsafe fn get<'a>(&self, id: Id<E>) -> Option<Self::Item<'a>>
             where
                 Self: 'a,
             {

--- a/src/world.rs
+++ b/src/world.rs
@@ -5,7 +5,7 @@ use derivative::Derivative;
 use crate::{
     entity::EntityVariant,
     query::{assert_borrow, fetch::Fetch, QueryBorrow, QueryItem, QueryMut, QueryShared},
-    Entity, EntityId, EntityRef, EntityRefMut, Query,
+    Entity, EntityRef, EntityRefMut, Id, Query,
 };
 
 pub trait WorldFetch<'w, F: Fetch>: Clone {
@@ -27,21 +27,17 @@ pub trait WorldData: Default + 'static {
 
     type Fetch<'w, F: Fetch + 'w>: WorldFetch<'w, F, Data = Self>;
 
-    fn spawn<E>(&mut self, entity: E) -> EntityId<E>
+    fn spawn<E>(&mut self, entity: E) -> Id<E>
     where
         E: EntityVariant<Self::Entity>;
 
-    fn despawn<E>(&mut self, id: EntityId<E>) -> Option<Self::Entity>
+    fn despawn<E>(&mut self, id: Id<E>) -> Option<Self::Entity>
     where
         E: EntityVariant<Self::Entity>;
 
-    fn spawn_at(
-        &mut self,
-        id: EntityId<Self::Entity>,
-        entity: Self::Entity,
-    ) -> Option<Self::Entity>;
+    fn spawn_at(&mut self, id: Id<Self::Entity>, entity: Self::Entity) -> Option<Self::Entity>;
 
-    fn contains(&self, id: EntityId<Self::Entity>) -> bool;
+    fn contains(&self, id: Id<Self::Entity>) -> bool;
 
     #[doc(hidden)]
     fn fetch<'w, F>(&'w self) -> Self::Fetch<'w, F>
@@ -64,14 +60,14 @@ impl<E: Entity> World<E> {
         Self::default()
     }
 
-    pub fn spawn<F>(&mut self, entity: F) -> EntityId<F>
+    pub fn spawn<F>(&mut self, entity: F) -> Id<F>
     where
         F: EntityVariant<E>,
     {
         self.0.spawn(entity)
     }
 
-    pub fn despawn<F>(&mut self, id: EntityId<F>) -> Option<E>
+    pub fn despawn<F>(&mut self, id: Id<F>) -> Option<E>
     where
         F: EntityVariant<E>,
     {
@@ -94,21 +90,21 @@ impl<E: Entity> World<E> {
         unsafe { Q::new(&self.0) }
     }
 
-    pub fn get<Q: QueryShared>(&self, id: EntityId<E>) -> Option<QueryItem<Q>> {
+    pub fn get<Q: QueryShared>(&self, id: Id<E>) -> Option<QueryItem<Q>> {
         let fetch = self.0.fetch::<<Q as Query>::Fetch<'_>>();
 
         // Safety: TODO
         unsafe { fetch.get(id.get()) }
     }
 
-    pub fn get_mut<Q: Query>(&mut self, id: EntityId<E>) -> Option<QueryItem<Q>> {
+    pub fn get_mut<Q: Query>(&mut self, id: Id<E>) -> Option<QueryItem<Q>> {
         let fetch = self.0.fetch::<<Q as Query>::Fetch<'_>>();
 
         // Safety: TODO
         unsafe { fetch.get(id.get()) }
     }
 
-    pub fn entity<F>(&self, id: EntityId<F>) -> Option<EntityRef<F>>
+    pub fn entity<F>(&self, id: Id<F>) -> Option<EntityRef<F>>
     where
         F: EntityVariant<E>,
     {
@@ -119,7 +115,7 @@ impl<E: Entity> World<E> {
         unsafe { fetch.get(id.get()) }
     }
 
-    pub fn entity_mut<F>(&mut self, id: EntityId<F>) -> Option<EntityRefMut<F>>
+    pub fn entity_mut<F>(&mut self, id: Id<F>) -> Option<EntityRefMut<F>>
     where
         F: EntityVariant<E>,
     {
@@ -130,11 +126,11 @@ impl<E: Entity> World<E> {
         unsafe { fetch.get(id.get()) }
     }
 
-    pub fn spawn_at(&mut self, id: EntityId<E>, entity: E) -> Option<E> {
+    pub fn spawn_at(&mut self, id: Id<E>, entity: E) -> Option<E> {
         self.0.spawn_at(id, entity)
     }
 
-    pub fn contains<F>(&self, id: EntityId<F>) -> bool
+    pub fn contains<F>(&self, id: Id<F>) -> bool
     where
         F: EntityVariant<E>,
     {


### PR DESCRIPTION
Typing `EntityId<Entity>` feels incredibly silly. Now it'll be `Id<Entity>`.